### PR TITLE
fix: ignore inline bundles

### DIFF
--- a/packages/parcel-runtime-precache-manifest/index.ts
+++ b/packages/parcel-runtime-precache-manifest/index.ts
@@ -21,7 +21,10 @@ export default new Runtime({
         // These should never have the `index.html` at the end
         url = url.slice(0, -10);
       }
-      if (bundle.env.context !== 'service-worker') {
+      if (
+        bundle.env.context !== 'service-worker' &&
+        !bundle.isInline // ignore bundles which are not outputted as separate files
+      ) {
         manifest.push({
           url: publicUrl + url,
           revision: bundle.hashReference

--- a/packages/parcel-runtime-precache-manifest/types/parcel__plugin.d.ts
+++ b/packages/parcel-runtime-precache-manifest/types/parcel__plugin.d.ts
@@ -20,6 +20,7 @@ type Bundle = {
   type: string;
   target: Target;
   env: Environment;
+  isInline: boolean;
 };
 
 type BundleGraph = {


### PR DESCRIPTION
add isInline property to the parcel plugin typing

Hey, I've fixed a bug I encountered while using this package - my project contained an html template file which was imported via
```js
import tpl from 'bundle-text:./tpl.html';
```
(it was a template for my component). This caused the plugin to error:
![image](https://user-images.githubusercontent.com/10456649/97816194-e56f9f00-1c93-11eb-83f6-f3cbb6b7c219.png)

It seemed that when the plugin outputted `HASH_REF_<here_an_id_of_inline_html_module>` the parcel failed miserably. This might be a problem with parcel v2 itself, but one the other hand - there is no sense for this plugin to provide service-workers with a filepaths pointing to inlined files (they do not end up as a separate files in the output directory), right?